### PR TITLE
Windows-support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,16 +1,16 @@
 const { sync: glob } = require("fast-glob");
 const path = require("path");
-const fs = require('fs');
+const fs = require("fs");
 
-function stripJsonComments (data) {
-  return data.replace(/\\"|"(?:\\"|[^"])*"|(\/\/.*|\/\*[\s\S]*?\*\/)/g, (m, g) => g ? "" : m);
+function stripJsonComments(data) {
+  return data.replace(/\\"|"(?:\\"|[^"])*"|(\/\/.*|\/\*[\s\S]*?\*\/)/g, (m, g) => (g ? "" : m));
 }
 
-module.exports = (relativeTsconfigPath = './tsconfig.json') => {
+module.exports = (relativeTsconfigPath = "./tsconfig.json") => {
   const absTsconfigPath = path.resolve(process.cwd(), relativeTsconfigPath);
-  let tsconfigData = fs.readFileSync(absTsconfigPath, 'utf8');
+  let tsconfigData = fs.readFileSync(absTsconfigPath, "utf8");
   tsconfigData = stripJsonComments(tsconfigData);
-  const {compilerOptions} = JSON.parse(tsconfigData);
+  const { compilerOptions } = JSON.parse(tsconfigData);
 
   const pathKeys = Object.keys(compilerOptions.paths);
   const re = new RegExp(`^(${pathKeys.join("|")})`);
@@ -22,11 +22,11 @@ module.exports = (relativeTsconfigPath = './tsconfig.json') => {
         const [pathDir] = pathKey.split("*");
         const file = args.path.replace(pathDir, "");
         for (const dir of compilerOptions.paths[pathKey]) {
-          const fileDir = path.resolve(process.cwd(), dir).replace("*", file)
+          const fileDir = path.resolve(process.cwd(), dir).replace("*", file);
           let [matchedFile] = glob(`${fileDir}.*`);
           if (!matchedFile) {
             const [matchIndexFile] = glob(`${fileDir}/index.*`);
-            matchedFile = matchIndexFile
+            matchedFile = matchIndexFile;
           }
           if (matchedFile) {
             return { path: matchedFile };

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const { sync: glob } = require("fast-glob");
 const path = require("path");
 const fs = require("fs");
+const normalizePath = process.platform === "win32" ? require("normalize-path") : (x) => x;
 
 function stripJsonComments(data) {
   return data.replace(/\\"|"(?:\\"|[^"])*"|(\/\/.*|\/\*[\s\S]*?\*\/)/g, (m, g) => (g ? "" : m));
@@ -22,7 +23,7 @@ module.exports = (relativeTsconfigPath = "./tsconfig.json") => {
         const [pathDir] = pathKey.split("*");
         const file = args.path.replace(pathDir, "");
         for (const dir of compilerOptions.paths[pathKey]) {
-          const fileDir = path.resolve(process.cwd(), dir).replace("*", file);
+          const fileDir = normalizePath(path.resolve(process.cwd(), dir).replace("*", file));
           let [matchedFile] = glob(`${fileDir}.*`);
           if (!matchedFile) {
             const [matchIndexFile] = glob(`${fileDir}/index.*`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "esbuild-ts-paths",
-  "version": "1.0.2",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "esbuild-ts-paths",
-      "version": "1.0.2",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
-        "fast-glob": "^3.2.11"
+        "fast-glob": "^3.2.11",
+        "normalize-path": "^3.0.0"
       },
       "devDependencies": {
         "prettier": "^2.5.1"
@@ -148,6 +149,14 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/picomatch": {
@@ -334,6 +343,11 @@
         "braces": "^3.0.1",
         "picomatch": "^2.2.3"
       }
+    },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
     },
     "picomatch": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "format": "prettier --write index.js"
   },
   "dependencies": {
-    "fast-glob": "^3.2.11"
+    "fast-glob": "^3.2.11",
+    "normalize-path": "^3.0.0"
   },
   "devDependencies": {
     "prettier": "^2.5.1"


### PR DESCRIPTION
Couldn't get this working on windows out of the box. Turns out that `fast-glob` doesn't support Windows-like paths with forward slashes in them, see https://github.com/mrmlnc/fast-glob/issues/240.

This PR "force-normalizes" paths to UNIX-like paths when on windows before feeding the result into `fast-glob`.